### PR TITLE
FunctionsにサンプルコードをデプロイできるようARMテンプレートを修正

### DIFF
--- a/arm-templates/functions.json
+++ b/arm-templates/functions.json
@@ -46,13 +46,21 @@
       "metadata": {
         "description": "The language worker runtime to load in the function app."
       }
+    },
+    "linuxFxVersion": {
+      "type": "string",
+      "defaultValue": "DOTNET|6.0",
+      "metadata": {
+        "description": "Required for Linux app to represent runtime stack in the format of 'runtime|runtimeVersion'. For example: 'python|3.9'"
+      }
     }
   },
   "variables": {
     "functionAppName": "[parameters('appName')]",
     "hostingPlanName": "[parameters('appName')]",
     "storageAccountName": "[format('{0}azfunctions', uniqueString(resourceGroup().id))]",
-    "functionWorkerRuntime": "[parameters('runtime')]"
+    "functionWorkerRuntime": "[parameters('runtime')]",
+    "linuxFxVersion": "[parameters('linuxFxVersion')]"
   },
   "resources": [
     {
@@ -78,14 +86,16 @@
         "name": "Y1",
         "tier": "Dynamic"
       },
-      "properties": {}
+      "properties": {
+        "reserved": true
+      }
     },
     {
       "type": "Microsoft.Web/sites",
       "apiVersion": "2021-03-01",
       "name": "[variables('functionAppName')]",
       "location": "[parameters('location')]",
-      "kind": "functionapp",
+      "kind": "functionapp,linux",
       "identity": {
         "type": "SystemAssigned"
       },
@@ -116,7 +126,7 @@
           ],
           "ftpsState": "FtpsOnly",
           "minTlsVersion": "1.2",
-          "netFrameworkVersion": "6.0"
+          "linuxFxVersion": "[variables('linuxFxVersion')]"
         },
         "httpsOnly": true
       },


### PR DESCRIPTION
下記Issueへの対応として、サンプルコードのデプロイに失敗するARMテンプレートを修正しました。
https://github.com/alterbooth-internal/hol-12factor-template/issues/70