### PR TITLE
サンプルコードを.NET6から.NET8にアップデート

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+ARG NODE_IMG="18-slim"
+ARG VARIANT="8.0"
+FROM node:${NODE_IMG} as node
+FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}
+
+# Copy node runtime from multi-stage build
+# https://github.com/BretFisher/nodejs-rocks-in-docker/blob/45354b2745f7accddea46a5fa7ef820c9388b1a5/dockerfiles/ubuntu-copy.Dockerfile#L17-L21
+COPY --from=node /usr/local/include/ /usr/local/include/
+COPY --from=node /usr/local/lib/ /usr/local/lib/
+COPY --from=node /usr/local/bin/ /usr/local/bin/
+
+# Install basic development tools
+RUN apt update && apt install -y less man-db sudo
+
+# Ensure default `node` user has access to `sudo`
+ARG USERNAME=node
+RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Set `DEVCONTAINER` environment variable to help with orientation
+ENV DEVCONTAINER=true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
+{
+    "name": "C# (.NET) with Node",
+    "build": {
+        "dockerfile": "./Dockerfile",
+        "args": {
+            "NODE_IMG": "18-slim",
+            "VARIANT": "8.0"
+        }
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/git:1": {}
+    },
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [5000, 5001],
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "dotnet dev-certs https --trust",
+
+    // Configure tool-specific properties.
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "EditorConfig.EditorConfig",
+                "ms-dotnettools.csharp",
+                "ms-vscode.vscode-node-azure-pack",
+                "taichi.vscode-textlint"
+            ]
+        }
+    }
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+}

--- a/TFApp_before/TFApp_before.csproj
+++ b/TFApp_before/TFApp_before.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>TFApp</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.12">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.12">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.11" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TFApp_before/TFApp_before.csproj
+++ b/TFApp_before/TFApp_before.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/TFApp_before/appsettings.json
+++ b/TFApp_before/appsettings.json
@@ -3,6 +3,11 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "ApplicationInsights": {
+      "LogLevel": {
+        "Default": "Information"
+      }
     }
   },
   "AllowedHosts": "*",

--- a/TFApp_library/TFApp_library.csproj
+++ b/TFApp_library/TFApp_library.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/arm-templates/functions.json
+++ b/arm-templates/functions.json
@@ -46,21 +46,13 @@
       "metadata": {
         "description": "The language worker runtime to load in the function app."
       }
-    },
-    "linuxFxVersion": {
-      "type": "string",
-      "defaultValue": "DOTNET|8.0",
-      "metadata": {
-        "description": "Required for Linux app to represent runtime stack in the format of 'runtime|runtimeVersion'. For example: 'python|3.9'"
-      }
     }
   },
   "variables": {
     "functionAppName": "[parameters('appName')]",
     "hostingPlanName": "[parameters('appName')]",
     "storageAccountName": "[format('{0}azfunctions', uniqueString(resourceGroup().id))]",
-    "functionWorkerRuntime": "[parameters('runtime')]",
-    "linuxFxVersion": "[parameters('linuxFxVersion')]"
+    "functionWorkerRuntime": "[parameters('runtime')]"
   },
   "resources": [
     {
@@ -125,8 +117,7 @@
             }
           ],
           "ftpsState": "FtpsOnly",
-          "minTlsVersion": "1.2",
-          "linuxFxVersion": "[variables('linuxFxVersion')]"
+          "minTlsVersion": "1.2"
         },
         "httpsOnly": true
       },

--- a/arm-templates/functions.json
+++ b/arm-templates/functions.json
@@ -49,7 +49,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "DOTNET|6.0",
+      "defaultValue": "DOTNET|8.0",
       "metadata": {
         "description": "Required for Linux app to represent runtime stack in the format of 'runtime|runtimeVersion'. For example: 'python|3.9'"
       }

--- a/arm-templates/functions.json
+++ b/arm-templates/functions.json
@@ -46,13 +46,21 @@
       "metadata": {
         "description": "The language worker runtime to load in the function app."
       }
+    },
+    "linuxFxVersion": {
+      "type": "string",
+      "defaultValue": "DOTNET|8.0",
+      "metadata": {
+        "description": "Required for Linux app to represent runtime stack in the format of 'runtime|runtimeVersion'. For example: 'python|3.9'"
+      }
     }
   },
   "variables": {
     "functionAppName": "[parameters('appName')]",
     "hostingPlanName": "[parameters('appName')]",
     "storageAccountName": "[format('{0}azfunctions', uniqueString(resourceGroup().id))]",
-    "functionWorkerRuntime": "[parameters('runtime')]"
+    "functionWorkerRuntime": "[parameters('runtime')]",
+    "linuxFxVersion": "[parameters('linuxFxVersion')]"
   },
   "resources": [
     {
@@ -121,7 +129,8 @@
             }
           ],
           "ftpsState": "FtpsOnly",
-          "minTlsVersion": "1.2"
+          "minTlsVersion": "1.2",
+          "linuxFxVersion": "[variables('linuxFxVersion')]"
         },
         "httpsOnly": true
       },

--- a/arm-templates/functions.json
+++ b/arm-templates/functions.json
@@ -114,6 +114,10 @@
             {
               "name": "FUNCTIONS_WORKER_RUNTIME",
               "value": "[variables('functionWorkerRuntime')]"
+            },
+            {
+              "name": "FUNCTIONS_INPROC_NET8_ENABLED",
+              "value": "1"
             }
           ],
           "ftpsState": "FtpsOnly",

--- a/weather-api/weather-api.csproj
+++ b/weather-api/weather-api.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <RootNamespace>WeatherApi</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="1.5.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi.Core" Version="1.5.1" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
サンプルコードを.NET6から.NET8にアップデートするため、以下の変更を行いました。
- TFApp_before、TFApp_library、weather-apiのプロジェクトファイルのTargetframeworkやパッケージ参照を.NET8に対応
- weather-apiをデプロイするAzure FunctionsのARMテンプレート`functions.json`のランタイムを.NET8に変更し、In-processモデルが動作するためのアプリ設定を追加
- GitHub Codespaces上でもハンズオンが実施できるよう、本リポジトリにも.devcontainerディレクトリを追加

また、既存のサンプルコードではApplication Insightsにログが送信されず、送信できるようにパッケージを追加した後も既定ではInformationレベルのログが送信されないようになっていましたので、Informationレベル以上のログをApplication Insightsに送信するための`Microsoft.ApplicationInsights.AspNetCore`パッケージの追加やappsettings.jsonへの設定追加も行いました。